### PR TITLE
Update dbus pkg-config name in Package.swift on macOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,5 +3,5 @@ import PackageDescription
 
 let package = Package(
     name: "CDBus",
-    pkgConfig: "dbus-1.0"
+    pkgConfig: "dbus-1"
 )


### PR DESCRIPTION
I tried building DBus Swift with dbus 1.12.0 installed by HomeBrew.
An error occured:
```
➜  DBus git:(master) swift build
'CDBus' dbus-1.0.pc: warning: couldn't find pc file
```

While `pkg-config --list-all` gives me:
```
dbus-1         dbus - Free desktop message bus
```